### PR TITLE
Hasher added to showcase and quickword link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ There are several applications based on or inspired by this template that you ca
 - [clips](https://github.com/hezral/clips)
 - [Mastodon-GTK+](https://github.com/AnaGelez/mastodon_gtk)
 - [Rogu](https://github.com/hezral/Rogu)
-- [quickword[(https://github.com/hezral/quickword)
+- [quickword](https://github.com/hezral/quickword)
 - [inspektor](https://github.com/hezral/inspektor)
 - [clips](https://github.com/hezral/clips)
-
+- [Hasher](https://github.com/JeysonFlores/hasher)
 ## 🐞 Problems/New Features?
 In any case, ask for support [here](https://github.com/brombinmirko/ElementaryPython/issues).
 


### PR DESCRIPTION
Hi, I'm the dev of [Hasher](https://github.com/JeysonFlores/hasher) which is based on this template. So as an acknowledge I added it to the showcase section of the readme. (And also I fixed the link for Quickword because it was wrong)